### PR TITLE
+ added missing -nox parameter

### DIFF
--- a/jsons/parameters.json
+++ b/jsons/parameters.json
@@ -7455,6 +7455,7 @@
       "msfragger_style_2": "digest_max_length",
       "msfragger_style_3": "digest_max_length",
       "myrimatch_style_1": "MaxPeptideLength",
+      "omssa_style_1": "-nox",
       "pglyco_db_style_1": "max_peptide_len",
       "pipi_style_1": "max_peptide_length",
       "ursgal_style_1": "max_pep_length"


### PR DESCRIPTION
while comparing ursgal1 and ursgal2 omssa execution I found out that "-nox" (max_pap_length) was missing in the uparma... 

Though it is a unique param and the other translations were existing. 

I added it to the parameters.json.