### PR TITLE
added missing value translations for ursgal_style_1 for id_213

### DIFF
--- a/jsons/parameters.json
+++ b/jsons/parameters.json
@@ -9122,6 +9122,30 @@
         [
           "default",
           "default"
+        ],
+        [
+          ".pepXML",
+          ".pepXML"
+        ],
+        [
+          ".mgf",
+          ".mgf"
+        ],
+        [
+          ".mzml",
+          ".mzml"
+        ],
+        [
+          "indexed_mzml",
+          "indexed_mzml"
+        ],
+        [
+          "parquet",
+          "parquet"
+        ],
+        [
+          ".mzid",
+          ".mzid"
         ]
       ],
       "xtandem_style_1": [


### PR DESCRIPTION
When working on xtandems, I realised that the parameter 213 `output_file_type: ".mzid"` was not translated properly to `yes` if set by the user (see branch `bug/uparma.translate` in uparma-py repo). 

While trying to figure out where the problem is, I cam along the following code in uparma.py:

https://github.com/uparma/uparma-py/blob/b1b52cb849eb6bfe0d87c8a4dfcf0fc6a7b9dfa6/uparma/uparma.py#L285-L290

Here the check if the value `.mzid` exists is first done in the original dict, meaning in the `ursgal_style_1`. Thus, I tried to remove it and directly check in the translated dict, as this param is only relevant for the `xtandem_style_1`. However, this broke the logic of the back and forward mapping of the params and thus I settled for another strategy as I did not want to touch that as it was already quite a tough time to bring it to that shape ^^

In order to maintain the correct parameter mapping, for id 213 all possible `output_file_types` have to be available in the `ursgal_style_1`, where they are simply translated to themselves...It kind of substitutes what was previously stored in `ursgal1/uparams` in `value_option/available_values`. And some of the params were already there (like for omssa) but not for all that might be used.

Not sure though if this is the most elegant way. I also only figured out my translation error by chance, since this param is not relevant for xtandem execution... Meaning, atm I don't know if and how to make sure that we will cover all such cases...