### PR TITLE
removed empty value_translations in id249

### DIFF
--- a/jsons/parameters.json
+++ b/jsons/parameters.json
@@ -10340,10 +10340,7 @@
       "conversion"
     ],
     "triggers_rerun": true,
-    "value_translations": {
-      "mzml2mgf_style_1": [],
-      "ursgal_style_1": []
-    },
+    "value_translations": {},
     "value_type": "int"
   },
   {


### PR DESCRIPTION
The value translation was not set properly in id249 and thus default_params were not imported properly. Therefore, the new pymzml mzml2mgf node was raising an error if parameter was not defined by the user.