### PR TITLE
Added missing value translation

### DIFF
--- a/jsons/parameters.json
+++ b/jsons/parameters.json
@@ -4612,6 +4612,10 @@
           "lysn_promisc"
         ],
         [
+          "nonspecific",
+          "nonspecific"
+        ],
+        [
           "pepsina",
           "pepsina"
         ],


### PR DESCRIPTION
The missing translation is due to the fact, that "nonspecific" was not part of the ursgal_style_1 value translation list. With this fix, it should be translated properly.

Should fix issue #19 