### PR TITLE
Fix for precursor_mass_tolerance_unit issue in e.g. omssa

### DIFF
--- a/jsons/parameters.json
+++ b/jsons/parameters.json
@@ -10427,6 +10427,14 @@
         [
           "da",
           "da"
+        ],
+        [
+          "ppm",
+          "ppm"
+        ],
+        [
+          "mmu",
+          "mmu"
         ]
       ],
       "xtandem_style_1": [


### PR DESCRIPTION
* added ppm and mmu tp ursgal_style_1 to avoid wrong formatting of these params in e.g. omssa